### PR TITLE
feat: 글 목록 및 상세 페이지 기능 구현

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -4,7 +4,6 @@ async function getPosts() {
   const res = await fetch("http://localhost:3000/api/posts", {
     cache: "no-store",
   });
-  
   return res.json();
 }
 
@@ -13,18 +12,19 @@ export default async function HomePage() {
 
   return (
     <main>
-      <h1 className="font-bold text-xl mb-3">
-        글 목록
-      </h1>
-      <ul className="space-y-3">
+      <h1 className="text-xl font-bold mb-4">글 목록</h1>
+      <ul className="space-y-2">
         {posts.map((post) => (
           <li key={post.id}>
-            <Link href={`/posts/${post.id}`} className="text-blue-500 underline">
+            <Link
+              href={`/posts/${post.id}`}
+              className="text-blue-600 underline"
+            >
               {post.title}
             </Link>
           </li>
         ))}
       </ul>
     </main>
-  )
+  );
 }

--- a/app/posts/[id]/page.jsx
+++ b/app/posts/[id]/page.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function PostDetailPage({ params }) {
+  const { id } = params;
+  const router = useRouter();
+  const [post, setPost] = useState(null);
+
+  useEffect(() => {
+    fetch(`/api/posts/${id}`)
+      .then((res) => {
+        if (res.status === 404) {
+          router.push("/not-found");
+          return;
+        }
+        return res.json();
+      })
+      .then(setPost);
+  }, [id, router]);
+
+  const handleDelete = async () => {
+    await fetch(`/api/posts/${id}`, {
+      method: "DELETE",
+    });
+    router.push("/");
+  };
+
+  if (!post) return <p>로딩 중...</p>;
+
+  return (
+    <main>
+      <h1 className="text-2xl font-bold">{post.title}</h1>
+      <p className="my-4">{post.content}</p>
+      <div className="space-x-2">
+        <Link href={`/edit/${id}`} className="text-blue-600 underline">
+          수정
+        </Link>
+        <button onClick={handleDelete} className="text-red-600 underline">
+          삭제
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/node": "22.15.19",
+        "@types/react": "19.1.4",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
         "tailwindcss": "^4"
@@ -1206,6 +1208,26 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "22.15.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
+      "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
+      "integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.32.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
@@ -2226,6 +2248,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6013,6 +6042,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.3.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.2"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
+    "@types/node": "22.15.19",
+    "@types/react": "19.1.4",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
호영 필수 요구사항 중,

2. 글 목록 보기 기능
- `/ ` 접속 시 글 리스트 형태로 전체 게시글 목록 노출
- 서버 API는 `/api/posts` 에 연결되어 있고 data.js에 저장되어있음
- 수영님과 충돌 발생 -> `rebase`로 충돌 해결 완료

3. 글 상세 페이지 기능
- `/posts/[id]` 로 접속 시 해당 글의 상세 내용 출력
- 동적 라우팅 위해 page.jsx 사용
- 클라이언트 컴포넌트 구성 
- 글 존재하지 않을 시 `not-found.js`로 이동
- 삭제, 수정 기능 연결 
- 로딩 처리 간단하게 구현